### PR TITLE
Make C++ mode default, remember user choice

### DIFF
--- a/src/apertiumview/ApertiumView.form
+++ b/src/apertiumview/ApertiumView.form
@@ -510,7 +510,6 @@
         <Property name="buttonGroup" type="javax.swing.ButtonGroup" editor="org.netbeans.modules.form.RADComponent$ButtonGroupPropertyEditor">
           <ComponentRef name="buttonGroup2"/>
         </Property>
-        <Property name="selected" type="boolean" value="true"/>
         <Property name="text" type="java.lang.String" value="Java"/>
       </Properties>
       <Events>
@@ -522,6 +521,7 @@
         <Property name="buttonGroup" type="javax.swing.ButtonGroup" editor="org.netbeans.modules.form.RADComponent$ButtonGroupPropertyEditor">
           <ComponentRef name="buttonGroup2"/>
         </Property>
+        <Property name="selected" type="boolean" value="true"/>
         <Property name="text" type="java.lang.String" value="C++ version"/>
       </Properties>
       <Events>

--- a/src/apertiumview/ApertiumView.java
+++ b/src/apertiumview/ApertiumView.java
@@ -352,6 +352,7 @@ public class ApertiumView extends javax.swing.JFrame {
 			markUnknownWordsMenuItem.setSelected(prefs.getBoolean("markUnknownWords", true));
 			showCommandsMenuItem.setSelected(prefs.getBoolean("showCommands", true));
 			transferRuleTracingMenuItem.setSelected(prefs.getBoolean("transferRuleTracing", true));
+			useJavaVersion.setSelected(prefs.getBoolean("useJavaVersion", false));
 
 			for (int i = 0; i < 10; i++) {
 				final String s = prefs.get("storedTexts." + i, "");
@@ -489,6 +490,7 @@ public class ApertiumView extends javax.swing.JFrame {
 		prefs.putBoolean("markUnknownWords", markUnknownWordsMenuItem.isSelected());
 		prefs.putBoolean("transferRuleTracing", transferRuleTracingMenuItem.isSelected());
 		prefs.putBoolean("local", local);
+		prefs.putBoolean("useJavaVersion", useJavaVersion.isSelected());
 
 		String remains = modeFiles;
 		int n = 0;
@@ -1035,7 +1037,6 @@ public class ApertiumView extends javax.swing.JFrame {
     jLabelUse.setText("Use");
 
     buttonGroup2.add(useJavaVersion);
-    useJavaVersion.setSelected(true);
     useJavaVersion.setText("Java");
     useJavaVersion.addActionListener(new java.awt.event.ActionListener() {
       public void actionPerformed(java.awt.event.ActionEvent evt) {
@@ -1045,6 +1046,7 @@ public class ApertiumView extends javax.swing.JFrame {
 
     buttonGroup2.add(useCppVersion);
     useCppVersion.setText("C++ version");
+    useCppVersion.setSelected(true);
     useCppVersion.addActionListener(new java.awt.event.ActionListener() {
       public void actionPerformed(java.awt.event.ActionEvent evt) {
         useCppVersionActionPerformed(evt);


### PR DESCRIPTION
This PR adds the following:

- By default and on the first run, use the C++ version of Apertium. Fixes #4 
- Keep the setting when closing the program to default to the user's preferred option. Fixes #3 

@nordfalk 